### PR TITLE
Setup Crowdin

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,40 @@
+# This workflow will run Crowdin Action that will upload new texts to Crowdin, download the newest translations and create a PR
+# For more information see: https://github.com/crowdin/github-action
+
+name: Crowdin Action
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
+  push: #temporary
+    branches: [ master ]
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: crowdin action
+        uses: crowdin/github-action@1.4.9
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Upload translations to Crowdin, only use true at initial run
+          upload_translations: true
+          # Make pull request of Crowdin translations
+          download_translations: true
+          # To download translations to the specified version branch
+          localization_branch_name: l10n_crowdin_translations
+          # Create pull request after pushing to branch
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_base_branch_name: 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,26 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "en.json",
+    "translation": "%two_letters_code%.json",
+    "languages_mapping": {
+      "two_letters_code": {
+        "pt-BR": "pt-br"
+      }
+    }
+  },
+  {
+    "source": "v2/en.json",
+    "translation": "v2/%two_letters_code%.json",
+    "languages_mapping": {
+      "two_letters_code": {
+        "pt-BR": "pt-br"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Hey everyone,

Just did some analysis of the current i18n workflow and it feels like GitHub issues and PRs reported by the community are not so easy to handle. The community translators can work together in Crowdin, translations would be delivered as PR and volunteers can raise issues for problematic strings via Crowdin.

I'm suggesting the integration with Crowdin via GitHub Actions. Crowdin is free for open-source projects. This integration works in the following way:
- the action runs every 6 hours (actually, it's up to you what trigger to use, it could also be a push to the default branch, for example)
- upload new source texts to the Crowdin project
- upload existing translations to Crowdin (using the `upload_translations` action config parameter, it's necessary only for the first time)
- download all the new translations from Crowdin and commit these translations to the `localization_branch_name`
- open a Pull Request with the latest translations.

You can find my demo Crowdin project here - [storyblok-demo](https://crowdin.com/project/storyblock-demo).

Example of the first PR that will be created by Crowdin Action - https://github.com/andrii-bodnar/storyblok-translations/pull/1 (Don't worry about the diffs - it just sorted keys according to keys order in the English file and added some missing keys with the English translations. The next PRs will include the new translations only)

Fixes #135
